### PR TITLE
Fix missing https in GCS CDN URLs

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,19 @@ import { App, Editor, Notice, Plugin, PluginSettingTab, Setting } from 'obsidian
 import { createStorageProvider } from './storageProviders';
 import { StorageProvider, PasterlySettings, DEFAULT_SETTINGS } from './types';
 
+const normalizeOptionalBaseUrl = (value: string): string => {
+	if (!value.trim()) {
+		return '';
+	}
+
+	const trimmedValue = value.trim();
+	const withProtocol = /^[a-z][a-z0-9+.-]*:\/\//i.test(trimmedValue)
+		? trimmedValue
+		: `https://${trimmedValue.replace(/^\/+/, '')}`;
+
+	return withProtocol.replace(/\/+$/, '');
+};
+
 /**
  * Creates a temporary placeholder in the editor while an image is being uploaded
  */
@@ -169,6 +182,11 @@ export default class Pasterly extends Plugin {
 
 	async loadSettings() {
 		this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
+		const normalizedCdnBaseUrl = normalizeOptionalBaseUrl(this.settings.gcsCdnBaseUrl);
+		if (normalizedCdnBaseUrl !== this.settings.gcsCdnBaseUrl) {
+			this.settings.gcsCdnBaseUrl = normalizedCdnBaseUrl;
+			await this.saveSettings();
+		}
 	}
 
 	async saveSettings() {
@@ -278,7 +296,7 @@ class PasterlySettingTab extends PluginSettingTab {
 					.setPlaceholder('https://cdn.example.com')
 					.setValue(this.plugin.settings.gcsCdnBaseUrl)
 					.onChange(async (value) => {
-						this.plugin.settings.gcsCdnBaseUrl = value;
+						this.plugin.settings.gcsCdnBaseUrl = normalizeOptionalBaseUrl(value);
 						await this.plugin.saveSettings();
 						this.plugin.debouncedInitializeStorage();
 					}));

--- a/src/storageProviders.ts
+++ b/src/storageProviders.ts
@@ -3,6 +3,23 @@ import { getStorage, ref, uploadBytes, getDownloadURL, FirebaseStorage as FBStor
 import { requestUrl } from 'obsidian';
 import { StorageProvider } from './types';
 
+const normalizeOptionalBaseUrl = (value: string | null): string | null => {
+    if (!value) {
+        return null;
+    }
+
+    const trimmedValue = value.trim();
+    if (!trimmedValue) {
+        return null;
+    }
+
+    const withProtocol = /^[a-z][a-z0-9+.-]*:\/\//i.test(trimmedValue)
+        ? trimmedValue
+        : `https://${trimmedValue.replace(/^\/+/, '')}`;
+
+    return withProtocol.replace(/\/+$/, '');
+};
+
 /**
  * Firebase Storage Provider
  * Handles file uploads to Firebase Storage with a specified bucket
@@ -106,7 +123,7 @@ export class GCSStorageProvider implements StorageProvider {
     constructor(bucketName: string, accessToken: string | null, cdnBaseUrl: string | null = null, useGcloudCli: boolean = false) {
         this.bucketName = bucketName;
         this.accessToken = accessToken;
-        this.cdnBaseUrl = cdnBaseUrl;
+        this.cdnBaseUrl = normalizeOptionalBaseUrl(cdnBaseUrl);
         this.useGcloudCli = useGcloudCli;
     }
 
@@ -166,8 +183,7 @@ export class GCSStorageProvider implements StorageProvider {
             if (response.status >= 200 && response.status < 300) {
                 // Return CDN URL if configured, otherwise GCS public URL
                 if (this.cdnBaseUrl) {
-                    const cdnUrl = this.cdnBaseUrl.replace(/\/$/, ''); // Remove trailing slash
-                    return `${cdnUrl}/${objectPath}`;
+                    return `${this.cdnBaseUrl}/${objectPath}`;
                 }
                 return `https://storage.googleapis.com/${this.bucketName}/${objectPath}`;
             } else {


### PR DESCRIPTION
## Summary
- normalize configured GCS CDN base URLs before generating markdown links
- prepend `https://` when users enter a bare hostname like `7b50d2de0634f64.cmccloud.com.vn`
- normalize existing saved settings on plugin load so older configs are fixed automatically

## Problem
When `CDN Base URL` is configured without a scheme, pasted image links are generated like:

```md
![1000](7b50d2de0634f64.cmccloud.com.vn/pasterly/image_....png)
```

That produces an invalid Markdown image URL because the plugin concatenates the raw setting value directly with the uploaded object path.

## Verification
- rebuilt the plugin bundle with `node esbuild.config.mjs production`
- confirmed the generated bundle includes the URL normalization logic


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced GCS CDN Base URL input handling with automatic normalization—URLs are now standardized with the https:// protocol when missing, trailing slashes are removed, and whitespace is trimmed for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->